### PR TITLE
⌨️ Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/check-ins @planningcenter/people @planningcenter/registrations @planningcenter/services


### PR DESCRIPTION
This fork is probably no longer necessary, but four apps still use it, so they get to own it.

ref: https://pco.slack.com/archives/C045TAXFPBK/p1700071570911889